### PR TITLE
数据库备份任务

### DIFF
--- a/app/Console/Commands/DbBakup.php
+++ b/app/Console/Commands/DbBakup.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class DbBakup extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'DbBakup';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '数据库备份';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $bak_setting = config('system.DbBakup');
+        //未开启备份，直接返回
+        if (!$bak_setting['ENABLE']) {
+            return;
+        }
+
+        //判断当前是否需要执行备份任务
+        $schedule_setting = $bak_setting['SCHEDULEDATE'];  
+        foreach ($schedule_setting as $type=>$setting) {
+            //如果设置的值为*，即任意，则不检查
+            if ($setting == '*') {
+                continue;
+            }
+
+            switch ($type) {
+                case 'month':
+                    $nowval = date('n');
+                    break;
+                case 'dayofmonth':
+                    $nowval = date('j');
+                    break;
+                case 'dayofweek':
+                    $nowval = date('w');
+                    break;
+                case 'hour':
+                    $nowval = date('G');
+                    break;
+                case 'minute':
+                    $nowval = date('i');
+                    if ($nowval[0] == '0') {
+                        $nowval = $nowval[1];
+                    } 
+                    break;
+            }
+
+            if (strpos(',', $setting)) {
+                $setting = explode(',', $setting);
+
+                if (!in_array($nowval, $setting)) {
+                    return;
+                }
+            } else {
+                if ($nowval != $setting) {
+                    return;
+                }
+            }
+        }
+
+        //拼接mysqldump命令
+        $mysqldump_setting = $bak_setting['MYSQLDUMP'];
+        $sqlfile = $bak_setting['DATADIR'].env('DB_DATABASE').'_'.date('Ymd.\s\q\l');
+        $include_tables = '';
+        $exclude_tables = '';
+        if ($bak_setting['INCLUDETBLS']) {
+            $include_tables = implode(' ', $bak_setting['INCLUDETBLS']);
+        }
+        if ($bak_setting['EXCLUDETBLS']) {
+            $exclude_tbls = [];
+            foreach ($bak_setting['EXCLUDETBLS'] as $tbl) {
+                $exclude_tbls[] = '--ignore-table='.env('DB_DATABASE').'.'.$tbl;
+            }
+            $exclude_tables = implode(' ', $exclude_tbls);
+        }
+        $cmd = sprintf(
+                "%s -u%s -p%s -h%s -P%s %s %s %s %s > %s",
+                $mysqldump_setting['path'],
+                $mysqldump_setting['user'],
+                $mysqldump_setting['pwd'],
+                env('DB_HOST'),
+                env('DB_PORT'),
+                $mysqldump_setting['options'],
+                env('DB_DATABASE'),
+                $include_tables,
+                $exclude_tables,
+                $sqlfile
+                );
+        system($cmd);
+
+        if ($bak_setting['GZIP']['enable']) {
+            system("{$bak_setting['GZIP']['path']} {$sqlfile}");
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        '\App\Console\Commands\DbBakup',
     ];
 
     /**
@@ -26,6 +26,7 @@ class Kernel extends ConsoleKernel
     {
         // $schedule->command('inspire')
         //          ->hourly();
+        $schedule->command('DbBakup')->withoutOverlapping();
     }
 
     /**

--- a/config/system.php
+++ b/config/system.php
@@ -8,4 +8,36 @@ return [
             'password'      =>  env('ADMIN_ROOT_PASSWORD', 'protavel'),
         ],
     ],
+    'DbBakup'=>[
+        //是否开启备份
+        'ENABLE'=>true,
+        //mysqldump的配置，包含路径、指定用户、密码
+        'MYSQLDUMP'=>[
+            'path'=>'mysqldump',
+            'user'=>env('DB_USERNAME'), //mysqldump使用的用户名、密码，可另外配置
+            'pwd'=>env('DB_PASSWORD'),
+            'options'=>'--opt',      //选项，默认为--opt
+        ],
+        //定期执行的日期，可以设置的配置有month 月份,dayofmonth 日,dayofweek 周几(周一到周日为1到7),hour 小时,minue 分钟
+        //值可以设置为三种情况:*为通配符任意时刻都符合;单个指定值;多个指定值，以英文半角逗号分隔
+        //如hour设置为18，表示18点执行；6,18，表示6点和18点都执行
+        'SCHEDULEDATE'=>[
+            'month'=>'*',
+            'dayofmonth'=>'*',
+            'dayofweek'=>'*',
+            'hour'=>'2',
+            'minute'=>'10',
+        ],
+        //导出的表，不配置导出所有的表
+        'INCLUDETBLS'=>['password_resets'],
+        //不导出的表
+        'EXCLUDETBLS'=>['failed_jobs'],
+        //导出文件是否gzip
+        'GZIP'=>[
+            'enable'=>true,
+            'path'=>'gzip',
+        ],
+        //备份文件保存的路径
+        'DATADIR'=>'/tmp/',
+    ],
 ];


### PR DESCRIPTION
增加了名为DbBakup的console command，配置在config/system.php中，可以设置备份任务运行执行的时间，以及指定备份的数据库表，生成的sql文件可以选择使用gzip进行压缩